### PR TITLE
fix of the acceptance of the mempool if `datacarrier=0`

### DIFF
--- a/src/policy/policy.cpp
+++ b/src/policy/policy.cpp
@@ -307,9 +307,9 @@ int64_t GetVirtualTransactionInputSize(const CTxIn& txin, int64_t nSigOpCost, un
     return GetVirtualTransactionSize(GetTransactionInputWeight(txin), nSigOpCost, bytes_per_sigop);
 }
 
-int32_t DatacarrierBytes(const CTransaction& tx, const CCoinsViewCache& view)
+uint32_t DatacarrierBytes(const CTransaction& tx, const CCoinsViewCache& view)
 {
-    int32_t ret{0};
+    uint32_t ret{0};
 
     for (const CTxIn& txin : tx.vin) {
         const CTxOut &utxo = view.AccessCoin(txin.prevout).out;

--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -168,6 +168,6 @@ static inline int64_t GetVirtualTransactionInputSize(const CTxIn& tx)
     return GetVirtualTransactionInputSize(tx, 0, 0);
 }
 
-int32_t DatacarrierBytes(const CTransaction& tx, const CCoinsViewCache& view);
+uint32_t DatacarrierBytes(const CTransaction& tx, const CCoinsViewCache& view);
 
 #endif // BITCOIN_POLICY_POLICY_H

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -812,7 +812,7 @@ bool MemPoolAccept::PreChecks(ATMPArgs& args, Workspace& ws)
         return state.Invalid(TxValidationResult::TX_INPUTS_NOT_STANDARD, "bad-txns-nonstandard-inputs");
     }
 
-    if (DatacarrierBytes(tx, m_view) > m_pool.m_max_datacarrier_bytes) {
+    if (m_pool.m_max_datacarrier_bytes && DatacarrierBytes(tx, m_view) > *m_pool.m_max_datacarrier_bytes) {
         return state.Invalid(TxValidationResult::TX_INPUTS_NOT_STANDARD, "txn-datacarrier-exceeded");
     }
 


### PR DESCRIPTION
Application of the suggested changes [here](https://github.com/bitcoin/bitcoin/pull/28408#discussion_r1332033451).