### PR TITLE
fix of the mempool txs acceptance if datacarriersize=0

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -812,7 +812,7 @@ bool MemPoolAccept::PreChecks(ATMPArgs& args, Workspace& ws)
         return state.Invalid(TxValidationResult::TX_INPUTS_NOT_STANDARD, "bad-txns-nonstandard-inputs");
     }
 
-    if (DatacarrierBytes(tx, m_view) > m_pool.m_max_datacarrier_bytes) {
+    if (DatacarrierBytes(tx, m_view) > *m_pool.m_max_datacarrier_bytes) {
         return state.Invalid(TxValidationResult::TX_INPUTS_NOT_STANDARD, "txn-datacarrier-exceeded");
     }
 


### PR DESCRIPTION
Access to content value for comparison with node user value.

Application of the suggested change #https://github.com/bitcoin/bitcoin/pull/28408#discussion_r1332912845