### PR TITLE
Fixing use case -datacarrier=0

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -812,7 +812,7 @@ bool MemPoolAccept::PreChecks(ATMPArgs& args, Workspace& ws)
         return state.Invalid(TxValidationResult::TX_INPUTS_NOT_STANDARD, "bad-txns-nonstandard-inputs");
     }
 
-    if (DatacarrierBytes(tx, m_view) > m_pool.m_max_datacarrier_bytes) {
+    if (!m_pool.m_max_datacarrier_bytes || (DatacarrierBytes(tx, m_view) > *m_pool.m_max_datacarrier_bytes)) {
         return state.Invalid(TxValidationResult::TX_INPUTS_NOT_STANDARD, "txn-datacarrier-exceeded");
     }
 


### PR DESCRIPTION
Without the fix, the new police rule is not enforced, if user puts parameter with value -datacarrier=0