### PR TITLE
primitives: Fix h1 byte count assert in v2 GetHash

### DIFF
--- a/src/chain.h
+++ b/src/chain.h
@@ -223,7 +223,7 @@ public:
 
     CBlockHeader GetBlockHeader() const
     {
-        return CBlockHeader(static_cast<const CompressedHeader&>(*this), pprev ? pprev->GetBlockHash() : uint256{});
+        return CBlockHeader(static_cast<const CompressedHeader&>(*this), pprev ? pprev->GetBlockHash() : uint256{}, nHeight);
     }
 
     uint256 GetBlockHash() const
@@ -352,7 +352,7 @@ public:
 
     CBlockHeader GetBlockHeader() const
     {
-        return CBlockHeader{static_cast<const CompressedHeader&>(*this), hashPrev};
+        return CBlockHeader{static_cast<const CompressedHeader&>(*this), hashPrev, nHeight};
     }
 
     SERIALIZE_METHODS(CDiskBlockIndex, obj)

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -26,8 +26,9 @@ enum BuriedDeployment : int16_t {
     DEPLOYMENT_DERSIG,
     DEPLOYMENT_CSV,
     DEPLOYMENT_SEGWIT,
+    DEPLOYMENT_BLAKE2B,
 };
-constexpr bool ValidDeployment(BuriedDeployment dep) { return dep <= DEPLOYMENT_SEGWIT; }
+constexpr bool ValidDeployment(BuriedDeployment dep) { return dep <= DEPLOYMENT_BLAKE2B; }
 
 enum DeploymentPos : uint16_t {
     DEPLOYMENT_TESTDUMMY,
@@ -105,6 +106,8 @@ struct Params {
      * Note that segwit v0 script rules are enforced on all blocks except the
      * BIP 16 exception blocks. */
     int SegwitHeight;
+    /** Block height at which BLAKE2b hardfork becomes active */
+    int Blake2bHeight;
     /** Don't warn about unknown BIP 9 activations below this height.
      * This prevents us from warning about the CSV and segwit activations. */
     int MinBIP9WarningHeight;
@@ -157,6 +160,8 @@ struct Params {
             return CSVHeight;
         case DEPLOYMENT_SEGWIT:
             return SegwitHeight;
+        case DEPLOYMENT_BLAKE2B:
+            return Blake2bHeight;
         } // no default case, so the compiler can warn about missing cases
         return std::numeric_limits<int>::max();
     }

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -108,6 +108,7 @@ struct Params {
     int SegwitHeight;
     /** Block height at which BLAKE2b hardfork becomes active */
     int Blake2bHeight;
+    uint8_t Blake2bTargetShift{20};
     /** Don't warn about unknown BIP 9 activations below this height.
      * This prevents us from warning about the CSV and segwit activations. */
     int MinBIP9WarningHeight;

--- a/src/crypto/CMakeLists.txt
+++ b/src/crypto/CMakeLists.txt
@@ -4,6 +4,7 @@
 
 add_library(bitcoin_crypto STATIC EXCLUDE_FROM_ALL
   aes.cpp
+  blake2b-ref.c
   chacha20.cpp
   chacha20poly1305.cpp
   hex_base.cpp

--- a/src/crypto/blake2-impl.h
+++ b/src/crypto/blake2-impl.h
@@ -1,0 +1,160 @@
+/*
+   BLAKE2 reference source code package - reference C implementations
+
+   Copyright 2012, Samuel Neves <sneves@dei.uc.pt>.  You may use this under the
+   terms of the CC0, the OpenSSL Licence, or the Apache Public License 2.0, at
+   your option.  The terms of these licenses can be found at:
+
+   - CC0 1.0 Universal : http://creativecommons.org/publicdomain/zero/1.0
+   - OpenSSL license   : https://www.openssl.org/source/license.html
+   - Apache 2.0        : http://www.apache.org/licenses/LICENSE-2.0
+
+   More information about the BLAKE2 hash function can be found at
+   https://blake2.net.
+*/
+#ifndef BLAKE2_IMPL_H
+#define BLAKE2_IMPL_H
+
+#include <stdint.h>
+#include <string.h>
+
+#if !defined(__cplusplus) && (!defined(__STDC_VERSION__) || __STDC_VERSION__ < 199901L)
+  #if   defined(_MSC_VER)
+    #define BLAKE2_INLINE __inline
+  #elif defined(__GNUC__)
+    #define BLAKE2_INLINE __inline__
+  #else
+    #define BLAKE2_INLINE
+  #endif
+#else
+  #define BLAKE2_INLINE inline
+#endif
+
+static BLAKE2_INLINE uint32_t load32( const void *src )
+{
+#if defined(NATIVE_LITTLE_ENDIAN)
+  uint32_t w;
+  memcpy(&w, src, sizeof w);
+  return w;
+#else
+  const uint8_t *p = ( const uint8_t * )src;
+  return (( uint32_t )( p[0] ) <<  0) |
+         (( uint32_t )( p[1] ) <<  8) |
+         (( uint32_t )( p[2] ) << 16) |
+         (( uint32_t )( p[3] ) << 24) ;
+#endif
+}
+
+static BLAKE2_INLINE uint64_t load64( const void *src )
+{
+#if defined(NATIVE_LITTLE_ENDIAN)
+  uint64_t w;
+  memcpy(&w, src, sizeof w);
+  return w;
+#else
+  const uint8_t *p = ( const uint8_t * )src;
+  return (( uint64_t )( p[0] ) <<  0) |
+         (( uint64_t )( p[1] ) <<  8) |
+         (( uint64_t )( p[2] ) << 16) |
+         (( uint64_t )( p[3] ) << 24) |
+         (( uint64_t )( p[4] ) << 32) |
+         (( uint64_t )( p[5] ) << 40) |
+         (( uint64_t )( p[6] ) << 48) |
+         (( uint64_t )( p[7] ) << 56) ;
+#endif
+}
+
+static BLAKE2_INLINE uint16_t load16( const void *src )
+{
+#if defined(NATIVE_LITTLE_ENDIAN)
+  uint16_t w;
+  memcpy(&w, src, sizeof w);
+  return w;
+#else
+  const uint8_t *p = ( const uint8_t * )src;
+  return ( uint16_t )((( uint32_t )( p[0] ) <<  0) |
+                      (( uint32_t )( p[1] ) <<  8));
+#endif
+}
+
+static BLAKE2_INLINE void store16( void *dst, uint16_t w )
+{
+#if defined(NATIVE_LITTLE_ENDIAN)
+  memcpy(dst, &w, sizeof w);
+#else
+  uint8_t *p = ( uint8_t * )dst;
+  *p++ = ( uint8_t )w; w >>= 8;
+  *p++ = ( uint8_t )w;
+#endif
+}
+
+static BLAKE2_INLINE void store32( void *dst, uint32_t w )
+{
+#if defined(NATIVE_LITTLE_ENDIAN)
+  memcpy(dst, &w, sizeof w);
+#else
+  uint8_t *p = ( uint8_t * )dst;
+  p[0] = (uint8_t)(w >>  0);
+  p[1] = (uint8_t)(w >>  8);
+  p[2] = (uint8_t)(w >> 16);
+  p[3] = (uint8_t)(w >> 24);
+#endif
+}
+
+static BLAKE2_INLINE void store64( void *dst, uint64_t w )
+{
+#if defined(NATIVE_LITTLE_ENDIAN)
+  memcpy(dst, &w, sizeof w);
+#else
+  uint8_t *p = ( uint8_t * )dst;
+  p[0] = (uint8_t)(w >>  0);
+  p[1] = (uint8_t)(w >>  8);
+  p[2] = (uint8_t)(w >> 16);
+  p[3] = (uint8_t)(w >> 24);
+  p[4] = (uint8_t)(w >> 32);
+  p[5] = (uint8_t)(w >> 40);
+  p[6] = (uint8_t)(w >> 48);
+  p[7] = (uint8_t)(w >> 56);
+#endif
+}
+
+static BLAKE2_INLINE uint64_t load48( const void *src )
+{
+  const uint8_t *p = ( const uint8_t * )src;
+  return (( uint64_t )( p[0] ) <<  0) |
+         (( uint64_t )( p[1] ) <<  8) |
+         (( uint64_t )( p[2] ) << 16) |
+         (( uint64_t )( p[3] ) << 24) |
+         (( uint64_t )( p[4] ) << 32) |
+         (( uint64_t )( p[5] ) << 40) ;
+}
+
+static BLAKE2_INLINE void store48( void *dst, uint64_t w )
+{
+  uint8_t *p = ( uint8_t * )dst;
+  p[0] = (uint8_t)(w >>  0);
+  p[1] = (uint8_t)(w >>  8);
+  p[2] = (uint8_t)(w >> 16);
+  p[3] = (uint8_t)(w >> 24);
+  p[4] = (uint8_t)(w >> 32);
+  p[5] = (uint8_t)(w >> 40);
+}
+
+static BLAKE2_INLINE uint32_t rotr32( const uint32_t w, const unsigned c )
+{
+  return ( w >> c ) | ( w << ( 32 - c ) );
+}
+
+static BLAKE2_INLINE uint64_t rotr64( const uint64_t w, const unsigned c )
+{
+  return ( w >> c ) | ( w << ( 64 - c ) );
+}
+
+/* prevents compiler optimizing out memset() */
+static BLAKE2_INLINE void secure_zero_memory(void *v, size_t n)
+{
+  static void *(*const volatile memset_v)(void *, int, size_t) = &memset;
+  memset_v(v, 0, n);
+}
+
+#endif

--- a/src/crypto/blake2.h
+++ b/src/crypto/blake2.h
@@ -1,0 +1,195 @@
+/*
+   BLAKE2 reference source code package - reference C implementations
+
+   Copyright 2012, Samuel Neves <sneves@dei.uc.pt>.  You may use this under the
+   terms of the CC0, the OpenSSL Licence, or the Apache Public License 2.0, at
+   your option.  The terms of these licenses can be found at:
+
+   - CC0 1.0 Universal : http://creativecommons.org/publicdomain/zero/1.0
+   - OpenSSL license   : https://www.openssl.org/source/license.html
+   - Apache 2.0        : http://www.apache.org/licenses/LICENSE-2.0
+
+   More information about the BLAKE2 hash function can be found at
+   https://blake2.net.
+*/
+#ifndef BLAKE2_H
+#define BLAKE2_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#if defined(_MSC_VER)
+#define BLAKE2_PACKED(x) __pragma(pack(push, 1)) x __pragma(pack(pop))
+#else
+#define BLAKE2_PACKED(x) x __attribute__((packed))
+#endif
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+  enum blake2s_constant
+  {
+    BLAKE2S_BLOCKBYTES = 64,
+    BLAKE2S_OUTBYTES   = 32,
+    BLAKE2S_KEYBYTES   = 32,
+    BLAKE2S_SALTBYTES  = 8,
+    BLAKE2S_PERSONALBYTES = 8
+  };
+
+  enum blake2b_constant
+  {
+    BLAKE2B_BLOCKBYTES = 128,
+    BLAKE2B_OUTBYTES   = 64,
+    BLAKE2B_KEYBYTES   = 64,
+    BLAKE2B_SALTBYTES  = 16,
+    BLAKE2B_PERSONALBYTES = 16
+  };
+
+  typedef struct blake2s_state__
+  {
+    uint32_t h[8];
+    uint32_t t[2];
+    uint32_t f[2];
+    uint8_t  buf[BLAKE2S_BLOCKBYTES];
+    size_t   buflen;
+    size_t   outlen;
+    uint8_t  last_node;
+  } blake2s_state;
+
+  typedef struct blake2b_state__
+  {
+    uint64_t h[8];
+    uint64_t t[2];
+    uint64_t f[2];
+    uint8_t  buf[BLAKE2B_BLOCKBYTES];
+    size_t   buflen;
+    size_t   outlen;
+    uint8_t  last_node;
+  } blake2b_state;
+
+  typedef struct blake2sp_state__
+  {
+    blake2s_state S[8][1];
+    blake2s_state R[1];
+    uint8_t       buf[8 * BLAKE2S_BLOCKBYTES];
+    size_t        buflen;
+    size_t        outlen;
+  } blake2sp_state;
+
+  typedef struct blake2bp_state__
+  {
+    blake2b_state S[4][1];
+    blake2b_state R[1];
+    uint8_t       buf[4 * BLAKE2B_BLOCKBYTES];
+    size_t        buflen;
+    size_t        outlen;
+  } blake2bp_state;
+
+
+  BLAKE2_PACKED(struct blake2s_param__
+  {
+    uint8_t  digest_length; /* 1 */
+    uint8_t  key_length;    /* 2 */
+    uint8_t  fanout;        /* 3 */
+    uint8_t  depth;         /* 4 */
+    uint32_t leaf_length;   /* 8 */
+    uint32_t node_offset;  /* 12 */
+    uint16_t xof_length;    /* 14 */
+    uint8_t  node_depth;    /* 15 */
+    uint8_t  inner_length;  /* 16 */
+    /* uint8_t  reserved[0]; */
+    uint8_t  salt[BLAKE2S_SALTBYTES]; /* 24 */
+    uint8_t  personal[BLAKE2S_PERSONALBYTES];  /* 32 */
+  });
+
+  typedef struct blake2s_param__ blake2s_param;
+
+  BLAKE2_PACKED(struct blake2b_param__
+  {
+    uint8_t  digest_length; /* 1 */
+    uint8_t  key_length;    /* 2 */
+    uint8_t  fanout;        /* 3 */
+    uint8_t  depth;         /* 4 */
+    uint32_t leaf_length;   /* 8 */
+    uint32_t node_offset;   /* 12 */
+    uint32_t xof_length;    /* 16 */
+    uint8_t  node_depth;    /* 17 */
+    uint8_t  inner_length;  /* 18 */
+    uint8_t  reserved[14];  /* 32 */
+    uint8_t  salt[BLAKE2B_SALTBYTES]; /* 48 */
+    uint8_t  personal[BLAKE2B_PERSONALBYTES];  /* 64 */
+  });
+
+  typedef struct blake2b_param__ blake2b_param;
+
+  typedef struct blake2xs_state__
+  {
+    blake2s_state S[1];
+    blake2s_param P[1];
+  } blake2xs_state;
+
+  typedef struct blake2xb_state__
+  {
+    blake2b_state S[1];
+    blake2b_param P[1];
+  } blake2xb_state;
+
+  /* Padded structs result in a compile-time error */
+  enum {
+    BLAKE2_DUMMY_1 = 1/(int)(sizeof(blake2s_param) == BLAKE2S_OUTBYTES),
+    BLAKE2_DUMMY_2 = 1/(int)(sizeof(blake2b_param) == BLAKE2B_OUTBYTES)
+  };
+
+  /* Streaming API */
+  int blake2s_init( blake2s_state *S, size_t outlen );
+  int blake2s_init_key( blake2s_state *S, size_t outlen, const void *key, size_t keylen );
+  int blake2s_init_param( blake2s_state *S, const blake2s_param *P );
+  int blake2s_update( blake2s_state *S, const void *in, size_t inlen );
+  int blake2s_final( blake2s_state *S, void *out, size_t outlen );
+
+  int blake2b_init( blake2b_state *S, size_t outlen );
+  int blake2b_init_key( blake2b_state *S, size_t outlen, const void *key, size_t keylen );
+  int blake2b_init_param( blake2b_state *S, const blake2b_param *P );
+  int blake2b_update( blake2b_state *S, const void *in, size_t inlen );
+  int blake2b_final( blake2b_state *S, void *out, size_t outlen );
+
+  int blake2sp_init( blake2sp_state *S, size_t outlen );
+  int blake2sp_init_key( blake2sp_state *S, size_t outlen, const void *key, size_t keylen );
+  int blake2sp_update( blake2sp_state *S, const void *in, size_t inlen );
+  int blake2sp_final( blake2sp_state *S, void *out, size_t outlen );
+
+  int blake2bp_init( blake2bp_state *S, size_t outlen );
+  int blake2bp_init_key( blake2bp_state *S, size_t outlen, const void *key, size_t keylen );
+  int blake2bp_update( blake2bp_state *S, const void *in, size_t inlen );
+  int blake2bp_final( blake2bp_state *S, void *out, size_t outlen );
+
+  /* Variable output length API */
+  int blake2xs_init( blake2xs_state *S, const size_t outlen );
+  int blake2xs_init_key( blake2xs_state *S, const size_t outlen, const void *key, size_t keylen );
+  int blake2xs_update( blake2xs_state *S, const void *in, size_t inlen );
+  int blake2xs_final(blake2xs_state *S, void *out, size_t outlen);
+
+  int blake2xb_init( blake2xb_state *S, const size_t outlen );
+  int blake2xb_init_key( blake2xb_state *S, const size_t outlen, const void *key, size_t keylen );
+  int blake2xb_update( blake2xb_state *S, const void *in, size_t inlen );
+  int blake2xb_final(blake2xb_state *S, void *out, size_t outlen);
+
+  /* Simple API */
+  int blake2s( void *out, size_t outlen, const void *in, size_t inlen, const void *key, size_t keylen );
+  int blake2b( void *out, size_t outlen, const void *in, size_t inlen, const void *key, size_t keylen );
+
+  int blake2sp( void *out, size_t outlen, const void *in, size_t inlen, const void *key, size_t keylen );
+  int blake2bp( void *out, size_t outlen, const void *in, size_t inlen, const void *key, size_t keylen );
+
+  int blake2xs( void *out, size_t outlen, const void *in, size_t inlen, const void *key, size_t keylen );
+  int blake2xb( void *out, size_t outlen, const void *in, size_t inlen, const void *key, size_t keylen );
+
+  /* This is simply an alias for blake2b */
+  int blake2( void *out, size_t outlen, const void *in, size_t inlen, const void *key, size_t keylen );
+
+#if defined(__cplusplus)
+}
+#endif
+
+#endif

--- a/src/crypto/blake2b-ref.c
+++ b/src/crypto/blake2b-ref.c
@@ -1,0 +1,379 @@
+/*
+   BLAKE2 reference source code package - reference C implementations
+
+   Copyright 2012, Samuel Neves <sneves@dei.uc.pt>.  You may use this under the
+   terms of the CC0, the OpenSSL Licence, or the Apache Public License 2.0, at
+   your option.  The terms of these licenses can be found at:
+
+   - CC0 1.0 Universal : http://creativecommons.org/publicdomain/zero/1.0
+   - OpenSSL license   : https://www.openssl.org/source/license.html
+   - Apache 2.0        : http://www.apache.org/licenses/LICENSE-2.0
+
+   More information about the BLAKE2 hash function can be found at
+   https://blake2.net.
+*/
+
+#include <stdint.h>
+#include <string.h>
+#include <stdio.h>
+
+#include "blake2.h"
+#include "blake2-impl.h"
+
+static const uint64_t blake2b_IV[8] =
+{
+  0x6a09e667f3bcc908ULL, 0xbb67ae8584caa73bULL,
+  0x3c6ef372fe94f82bULL, 0xa54ff53a5f1d36f1ULL,
+  0x510e527fade682d1ULL, 0x9b05688c2b3e6c1fULL,
+  0x1f83d9abfb41bd6bULL, 0x5be0cd19137e2179ULL
+};
+
+static const uint8_t blake2b_sigma[12][16] =
+{
+  {  0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15 } ,
+  { 14, 10,  4,  8,  9, 15, 13,  6,  1, 12,  0,  2, 11,  7,  5,  3 } ,
+  { 11,  8, 12,  0,  5,  2, 15, 13, 10, 14,  3,  6,  7,  1,  9,  4 } ,
+  {  7,  9,  3,  1, 13, 12, 11, 14,  2,  6,  5, 10,  4,  0, 15,  8 } ,
+  {  9,  0,  5,  7,  2,  4, 10, 15, 14,  1, 11, 12,  6,  8,  3, 13 } ,
+  {  2, 12,  6, 10,  0, 11,  8,  3,  4, 13,  7,  5, 15, 14,  1,  9 } ,
+  { 12,  5,  1, 15, 14, 13,  4, 10,  0,  7,  6,  3,  9,  2,  8, 11 } ,
+  { 13, 11,  7, 14, 12,  1,  3,  9,  5,  0, 15,  4,  8,  6,  2, 10 } ,
+  {  6, 15, 14,  9, 11,  3,  0,  8, 12,  2, 13,  7,  1,  4, 10,  5 } ,
+  { 10,  2,  8,  4,  7,  6,  1,  5, 15, 11,  9, 14,  3, 12, 13 , 0 } ,
+  {  0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15 } ,
+  { 14, 10,  4,  8,  9, 15, 13,  6,  1, 12,  0,  2, 11,  7,  5,  3 }
+};
+
+
+static void blake2b_set_lastnode( blake2b_state *S )
+{
+  S->f[1] = (uint64_t)-1;
+}
+
+/* Some helper functions, not necessarily useful */
+static int blake2b_is_lastblock( const blake2b_state *S )
+{
+  return S->f[0] != 0;
+}
+
+static void blake2b_set_lastblock( blake2b_state *S )
+{
+  if( S->last_node ) blake2b_set_lastnode( S );
+
+  S->f[0] = (uint64_t)-1;
+}
+
+static void blake2b_increment_counter( blake2b_state *S, const uint64_t inc )
+{
+  S->t[0] += inc;
+  S->t[1] += ( S->t[0] < inc );
+}
+
+static void blake2b_init0( blake2b_state *S )
+{
+  size_t i;
+  memset( S, 0, sizeof( blake2b_state ) );
+
+  for( i = 0; i < 8; ++i ) S->h[i] = blake2b_IV[i];
+}
+
+/* init xors IV with input parameter block */
+int blake2b_init_param( blake2b_state *S, const blake2b_param *P )
+{
+  const uint8_t *p = ( const uint8_t * )( P );
+  size_t i;
+
+  blake2b_init0( S );
+
+  /* IV XOR ParamBlock */
+  for( i = 0; i < 8; ++i )
+    S->h[i] ^= load64( p + sizeof( S->h[i] ) * i );
+
+  S->outlen = P->digest_length;
+  return 0;
+}
+
+
+
+int blake2b_init( blake2b_state *S, size_t outlen )
+{
+  blake2b_param P[1];
+
+  if ( ( !outlen ) || ( outlen > BLAKE2B_OUTBYTES ) ) return -1;
+
+  P->digest_length = (uint8_t)outlen;
+  P->key_length    = 0;
+  P->fanout        = 1;
+  P->depth         = 1;
+  store32( &P->leaf_length, 0 );
+  store32( &P->node_offset, 0 );
+  store32( &P->xof_length, 0 );
+  P->node_depth    = 0;
+  P->inner_length  = 0;
+  memset( P->reserved, 0, sizeof( P->reserved ) );
+  memset( P->salt,     0, sizeof( P->salt ) );
+  memset( P->personal, 0, sizeof( P->personal ) );
+  return blake2b_init_param( S, P );
+}
+
+
+int blake2b_init_key( blake2b_state *S, size_t outlen, const void *key, size_t keylen )
+{
+  blake2b_param P[1];
+
+  if ( ( !outlen ) || ( outlen > BLAKE2B_OUTBYTES ) ) return -1;
+
+  if ( !key || !keylen || keylen > BLAKE2B_KEYBYTES ) return -1;
+
+  P->digest_length = (uint8_t)outlen;
+  P->key_length    = (uint8_t)keylen;
+  P->fanout        = 1;
+  P->depth         = 1;
+  store32( &P->leaf_length, 0 );
+  store32( &P->node_offset, 0 );
+  store32( &P->xof_length, 0 );
+  P->node_depth    = 0;
+  P->inner_length  = 0;
+  memset( P->reserved, 0, sizeof( P->reserved ) );
+  memset( P->salt,     0, sizeof( P->salt ) );
+  memset( P->personal, 0, sizeof( P->personal ) );
+
+  if( blake2b_init_param( S, P ) < 0 ) return -1;
+
+  {
+    uint8_t block[BLAKE2B_BLOCKBYTES];
+    memset( block, 0, BLAKE2B_BLOCKBYTES );
+    memcpy( block, key, keylen );
+    blake2b_update( S, block, BLAKE2B_BLOCKBYTES );
+    secure_zero_memory( block, BLAKE2B_BLOCKBYTES ); /* Burn the key from stack */
+  }
+  return 0;
+}
+
+#define G(r,i,a,b,c,d)                      \
+  do {                                      \
+    a = a + b + m[blake2b_sigma[r][2*i+0]]; \
+    d = rotr64(d ^ a, 32);                  \
+    c = c + d;                              \
+    b = rotr64(b ^ c, 24);                  \
+    a = a + b + m[blake2b_sigma[r][2*i+1]]; \
+    d = rotr64(d ^ a, 16);                  \
+    c = c + d;                              \
+    b = rotr64(b ^ c, 63);                  \
+  } while(0)
+
+#define ROUND(r)                    \
+  do {                              \
+    G(r,0,v[ 0],v[ 4],v[ 8],v[12]); \
+    G(r,1,v[ 1],v[ 5],v[ 9],v[13]); \
+    G(r,2,v[ 2],v[ 6],v[10],v[14]); \
+    G(r,3,v[ 3],v[ 7],v[11],v[15]); \
+    G(r,4,v[ 0],v[ 5],v[10],v[15]); \
+    G(r,5,v[ 1],v[ 6],v[11],v[12]); \
+    G(r,6,v[ 2],v[ 7],v[ 8],v[13]); \
+    G(r,7,v[ 3],v[ 4],v[ 9],v[14]); \
+  } while(0)
+
+static void blake2b_compress( blake2b_state *S, const uint8_t block[BLAKE2B_BLOCKBYTES] )
+{
+  uint64_t m[16];
+  uint64_t v[16];
+  size_t i;
+
+  for( i = 0; i < 16; ++i ) {
+    m[i] = load64( block + i * sizeof( m[i] ) );
+  }
+
+  for( i = 0; i < 8; ++i ) {
+    v[i] = S->h[i];
+  }
+
+  v[ 8] = blake2b_IV[0];
+  v[ 9] = blake2b_IV[1];
+  v[10] = blake2b_IV[2];
+  v[11] = blake2b_IV[3];
+  v[12] = blake2b_IV[4] ^ S->t[0];
+  v[13] = blake2b_IV[5] ^ S->t[1];
+  v[14] = blake2b_IV[6] ^ S->f[0];
+  v[15] = blake2b_IV[7] ^ S->f[1];
+
+  ROUND( 0 );
+  ROUND( 1 );
+  ROUND( 2 );
+  ROUND( 3 );
+  ROUND( 4 );
+  ROUND( 5 );
+  ROUND( 6 );
+  ROUND( 7 );
+  ROUND( 8 );
+  ROUND( 9 );
+  ROUND( 10 );
+  ROUND( 11 );
+
+  for( i = 0; i < 8; ++i ) {
+    S->h[i] = S->h[i] ^ v[i] ^ v[i + 8];
+  }
+}
+
+#undef G
+#undef ROUND
+
+int blake2b_update( blake2b_state *S, const void *pin, size_t inlen )
+{
+  const unsigned char * in = (const unsigned char *)pin;
+  if( inlen > 0 )
+  {
+    size_t left = S->buflen;
+    size_t fill = BLAKE2B_BLOCKBYTES - left;
+    if( inlen > fill )
+    {
+      S->buflen = 0;
+      memcpy( S->buf + left, in, fill ); /* Fill buffer */
+      blake2b_increment_counter( S, BLAKE2B_BLOCKBYTES );
+      blake2b_compress( S, S->buf ); /* Compress */
+      in += fill; inlen -= fill;
+      while(inlen > BLAKE2B_BLOCKBYTES) {
+        blake2b_increment_counter(S, BLAKE2B_BLOCKBYTES);
+        blake2b_compress( S, in );
+        in += BLAKE2B_BLOCKBYTES;
+        inlen -= BLAKE2B_BLOCKBYTES;
+      }
+    }
+    memcpy( S->buf + S->buflen, in, inlen );
+    S->buflen += inlen;
+  }
+  return 0;
+}
+
+int blake2b_final( blake2b_state *S, void *out, size_t outlen )
+{
+  uint8_t buffer[BLAKE2B_OUTBYTES] = {0};
+  size_t i;
+
+  if( out == NULL || outlen < S->outlen )
+    return -1;
+
+  if( blake2b_is_lastblock( S ) )
+    return -1;
+
+  blake2b_increment_counter( S, S->buflen );
+  blake2b_set_lastblock( S );
+  memset( S->buf + S->buflen, 0, BLAKE2B_BLOCKBYTES - S->buflen ); /* Padding */
+  blake2b_compress( S, S->buf );
+
+  for( i = 0; i < 8; ++i ) /* Output full hash to temp buffer */
+    store64( buffer + sizeof( S->h[i] ) * i, S->h[i] );
+
+  memcpy( out, buffer, S->outlen );
+  secure_zero_memory(buffer, sizeof(buffer));
+  return 0;
+}
+
+/* inlen, at least, should be uint64_t. Others can be size_t. */
+int blake2b( void *out, size_t outlen, const void *in, size_t inlen, const void *key, size_t keylen )
+{
+  blake2b_state S[1];
+
+  /* Verify parameters */
+  if ( NULL == in && inlen > 0 ) return -1;
+
+  if ( NULL == out ) return -1;
+
+  if( NULL == key && keylen > 0 ) return -1;
+
+  if( !outlen || outlen > BLAKE2B_OUTBYTES ) return -1;
+
+  if( keylen > BLAKE2B_KEYBYTES ) return -1;
+
+  if( keylen > 0 )
+  {
+    if( blake2b_init_key( S, outlen, key, keylen ) < 0 ) return -1;
+  }
+  else
+  {
+    if( blake2b_init( S, outlen ) < 0 ) return -1;
+  }
+
+  blake2b_update( S, ( const uint8_t * )in, inlen );
+  blake2b_final( S, out, outlen );
+  return 0;
+}
+
+int blake2( void *out, size_t outlen, const void *in, size_t inlen, const void *key, size_t keylen ) {
+  return blake2b(out, outlen, in, inlen, key, keylen);
+}
+
+#if defined(SUPERCOP)
+int crypto_hash( unsigned char *out, unsigned char *in, unsigned long long inlen )
+{
+  return blake2b( out, BLAKE2B_OUTBYTES, in, inlen, NULL, 0 );
+}
+#endif
+
+#if defined(BLAKE2B_SELFTEST)
+#include <string.h>
+#include "blake2-kat.h"
+int main( void )
+{
+  uint8_t key[BLAKE2B_KEYBYTES];
+  uint8_t buf[BLAKE2_KAT_LENGTH];
+  size_t i, step;
+
+  for( i = 0; i < BLAKE2B_KEYBYTES; ++i )
+    key[i] = ( uint8_t )i;
+
+  for( i = 0; i < BLAKE2_KAT_LENGTH; ++i )
+    buf[i] = ( uint8_t )i;
+
+  /* Test simple API */
+  for( i = 0; i < BLAKE2_KAT_LENGTH; ++i )
+  {
+    uint8_t hash[BLAKE2B_OUTBYTES];
+    blake2b( hash, BLAKE2B_OUTBYTES, buf, i, key, BLAKE2B_KEYBYTES );
+
+    if( 0 != memcmp( hash, blake2b_keyed_kat[i], BLAKE2B_OUTBYTES ) )
+    {
+      goto fail;
+    }
+  }
+
+  /* Test streaming API */
+  for(step = 1; step < BLAKE2B_BLOCKBYTES; ++step) {
+    for (i = 0; i < BLAKE2_KAT_LENGTH; ++i) {
+      uint8_t hash[BLAKE2B_OUTBYTES];
+      blake2b_state S;
+      uint8_t * p = buf;
+      size_t mlen = i;
+      int err = 0;
+
+      if( (err = blake2b_init_key(&S, BLAKE2B_OUTBYTES, key, BLAKE2B_KEYBYTES)) < 0 ) {
+        goto fail;
+      }
+
+      while (mlen >= step) {
+        if ( (err = blake2b_update(&S, p, step)) < 0 ) {
+          goto fail;
+        }
+        mlen -= step;
+        p += step;
+      }
+      if ( (err = blake2b_update(&S, p, mlen)) < 0) {
+        goto fail;
+      }
+      if ( (err = blake2b_final(&S, hash, BLAKE2B_OUTBYTES)) < 0) {
+        goto fail;
+      }
+
+      if (0 != memcmp(hash, blake2b_keyed_kat[i], BLAKE2B_OUTBYTES)) {
+        goto fail;
+      }
+    }
+  }
+
+  puts( "ok" );
+  return 0;
+fail:
+  puts("error");
+  return -1;
+}
+#endif

--- a/src/crypto/sha256.h
+++ b/src/crypto/sha256.h
@@ -24,6 +24,11 @@ public:
     CSHA256& Write(const unsigned char* data, size_t len);
     void Finalize(unsigned char hash[OUTPUT_SIZE]);
     CSHA256& Reset();
+
+    uint64_t BytesWritten() const
+    {
+        return bytes;
+    }
 };
 
 namespace sha256_implementation {

--- a/src/deploymentinfo.cpp
+++ b/src/deploymentinfo.cpp
@@ -37,6 +37,8 @@ std::string DeploymentName(Consensus::BuriedDeployment dep)
         return "csv";
     case Consensus::DEPLOYMENT_SEGWIT:
         return "segwit";
+    case Consensus::DEPLOYMENT_BLAKE2B:
+        return "blake2b";
     } // no default case, so the compiler can warn about missing cases
     return "";
 }
@@ -53,6 +55,8 @@ std::optional<Consensus::BuriedDeployment> GetBuriedDeployment(const std::string
         return Consensus::BuriedDeployment::DEPLOYMENT_CLTV;
     } else if (name == "csv") {
         return Consensus::BuriedDeployment::DEPLOYMENT_CSV;
+    } else if (name == "blake2b") {
+        return Consensus::BuriedDeployment::DEPLOYMENT_BLAKE2B;
     }
     return std::nullopt;
 }

--- a/src/hash.h
+++ b/src/hash.h
@@ -108,6 +108,11 @@ public:
         ctx.Write(UCharCast(src.data()), src.size());
     }
 
+    uint64_t BytesWritten() const
+    {
+        return ctx.BytesWritten();
+    }
+
     /** Compute the double-SHA256 hash of all data written to this object.
      *
      * Invalidates this object.

--- a/src/headerssync.cpp
+++ b/src/headerssync.cpp
@@ -9,6 +9,8 @@
 #include <util/time.h>
 #include <util/vector.h>
 
+#include <limits>
+
 // The two constants below are computed using the simulation script in
 // contrib/devtools/headerssync-params.py.
 
@@ -287,7 +289,9 @@ std::vector<CBlockHeader> HeadersSyncState::PopHeadersReadyForAcceptance()
 
     while (m_redownloaded_headers.size() > REDOWNLOAD_BUFFER_SIZE ||
             (m_redownloaded_headers.size() > 0 && m_process_all_remaining_headers)) {
-        ret.emplace_back(CBlockHeader(m_redownloaded_headers.front(), m_redownload_buffer_first_prev_hash));
+        const int64_t height{m_redownload_buffer_last_height - static_cast<int64_t>(m_redownloaded_headers.size()) + 1};
+        Assume(height >= 0 && height <= std::numeric_limits<int32_t>::max());
+        ret.emplace_back(CBlockHeader(m_redownloaded_headers.front(), m_redownload_buffer_first_prev_hash, static_cast<int32_t>(height)));
         m_redownloaded_headers.pop_front();
         m_redownload_buffer_first_prev_hash = ret.back().GetHash();
     }

--- a/src/headerssync.cpp
+++ b/src/headerssync.cpp
@@ -21,7 +21,7 @@ constexpr size_t REDOWNLOAD_BUFFER_SIZE{15009}; // 15009/632 = ~23.7 commitments
 
 // Our memory analysis assumes 48 bytes for a CompressedHeader (so we should
 // re-calculate parameters if we compress further)
-static_assert(sizeof(CompressedHeader) == 48);
+// FIXME: static_assert(sizeof(CompressedHeader) == 48);
 
 HeadersSyncState::HeadersSyncState(NodeId id, const Consensus::Params& consensus_params,
         const CBlockIndex* chain_start, const arith_uint256& minimum_required_work) :

--- a/src/kernel/chainparams.cpp
+++ b/src/kernel/chainparams.cpp
@@ -653,6 +653,9 @@ public:
 
         for (const auto& [dep, height] : opts.activation_heights) {
             switch (dep) {
+            case Consensus::BuriedDeployment::DEPLOYMENT_BLAKE2B:
+                consensus.Blake2bHeight = int{height};
+                break;
             case Consensus::BuriedDeployment::DEPLOYMENT_SEGWIT:
                 consensus.SegwitHeight = int{height};
                 break;

--- a/src/node/miner.cpp
+++ b/src/node/miner.cpp
@@ -212,6 +212,7 @@ std::shared_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock()
     // Fill in header
     pblock->hashPrevBlock  = pindexPrev->GetBlockHash();
     UpdateTime(pblock, chainparams.GetConsensus(), pindexPrev);
+    pblock->m_txcount      = pblock->m_header_v2 ? pblock->vtx.size() : 0;
     pblock->nBits          = GetNextWorkRequired(pindexPrev, pblock, chainparams.GetConsensus());
     pblock->nNonce         = 0;
     pblocktemplate->vTxSigOpsCost[0] = WITNESS_SCALE_FACTOR * GetLegacySigOpCount(*pblock->vtx[0]);

--- a/src/node/miner.cpp
+++ b/src/node/miner.cpp
@@ -53,6 +53,7 @@ int64_t UpdateTime(CBlockHeader* pblock, const Consensus::Params& consensusParam
     if (nOldTime < nNewTime) {
         pblock->nTime = nNewTime;
     }
+    pblock->m_height = pblock->m_header_v2 ? pindexPrev->nHeight + 1 : 0;
 
     // Updating time can change work required on testnet:
     if (consensusParams.fPowAllowMinDifficultyBlocks) {

--- a/src/node/miner.cpp
+++ b/src/node/miner.cpp
@@ -53,6 +53,7 @@ int64_t UpdateTime(CBlockHeader* pblock, const Consensus::Params& consensusParam
     if (nOldTime < nNewTime) {
         pblock->nTime = nNewTime;
     }
+    pblock->m_header_v2 = pindexPrev->nHeight + 1 >= consensusParams.DeploymentHeight(Consensus::DEPLOYMENT_BLAKE2B);
     pblock->m_height = pblock->m_header_v2 ? pindexPrev->nHeight + 1 : 0;
 
     // Updating time can change work required on testnet:

--- a/src/pow.cpp
+++ b/src/pow.cpp
@@ -11,6 +11,25 @@
 #include <uint256.h>
 #include <util/check.h>
 
+/** One-off target shift applied to the first block under a new PoW algorithm.
+ *
+ * Shared by GetNextWorkRequired and PermittedDifficultyTransition so the value
+ * that gets produced and the value that gets accepted cannot drift apart.
+ */
+static unsigned int ApplyBlake2bTargetShift(unsigned int nBits, const Consensus::Params& params)
+{
+    arith_uint256 bnNew;
+    bnNew.SetCompact(nBits);
+    const arith_uint256 bnPowLimit = UintToArith256(params.powLimit);
+    const unsigned int shift{params.Blake2bTargetShift};
+    if (bnNew > (bnPowLimit >> shift)) {
+        bnNew = bnPowLimit;
+    } else {
+        bnNew <<= shift;
+    }
+    return bnNew.GetCompact();
+}
+
 unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHeader *pblock, const Consensus::Params& params)
 {
     unsigned int nProofOfWorkLimit = UintToArith256(params.powLimit).GetCompact();
@@ -46,6 +65,11 @@ unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHead
         assert(pindexFirst);
 
         nBits = CalculateNextWorkRequired(pindexLast, pindexFirst->GetBlockTime(), params);
+    }
+
+    if (pindexLast->nHeight + 1 == params.DeploymentHeight(Consensus::DEPLOYMENT_BLAKE2B)) {
+        // Adjust the target for the first block mined under a new PoW algorithm.
+        nBits = ApplyBlake2bTargetShift(nBits, params);
     }
 
     return nBits;
@@ -93,6 +117,14 @@ unsigned int CalculateNextWorkRequired(const CBlockIndex* pindexLast, int64_t nF
 bool PermittedDifficultyTransition(const Consensus::Params& params, int64_t height, uint32_t old_nbits, uint32_t new_nbits)
 {
     if (params.fPowAllowMinDifficultyBlocks) return true;
+
+    // Across a PoW-algorithm change, GetNextWorkRequired shifts the target once
+    // before returning it. Rebase the comparison onto the shifted target so the
+    // usual limits below apply to the change on top of it, rather than
+    // rejecting the shift itself.
+    if (height == params.DeploymentHeight(Consensus::DEPLOYMENT_BLAKE2B)) {
+        old_nbits = ApplyBlake2bTargetShift(old_nbits, params);
+    }
 
     if (height % params.DifficultyAdjustmentInterval() == 0) {
         int64_t smallest_timespan = params.nPowTargetTimespan/4;

--- a/src/pow.cpp
+++ b/src/pow.cpp
@@ -15,6 +15,8 @@ unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHead
 {
     unsigned int nProofOfWorkLimit = UintToArith256(params.powLimit).GetCompact();
 
+    unsigned int nBits;
+
     // Only change once per difficulty adjustment interval
     if ((pindexLast->nHeight+1) % params.DifficultyAdjustmentInterval() != 0)
     {
@@ -27,23 +29,26 @@ unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHead
                 return nProofOfWorkLimit;
             else
             {
-                // Return the last non-special-min-difficulty-rules-block
+                // Look back to the last non-special-min-difficulty-rules-block
                 const CBlockIndex* pindex = pindexLast;
                 while (pindex->pprev && pindex->nHeight % params.DifficultyAdjustmentInterval() != 0 && pindex->nBits == nProofOfWorkLimit)
                     pindex = pindex->pprev;
-                return pindex->nBits;
+                nBits = pindex->nBits;
             }
+        } else {
+            nBits = pindexLast->nBits;
         }
-        return pindexLast->nBits;
+    } else {
+        // Go back by what we want to be 14 days worth of blocks
+        int nHeightFirst = pindexLast->nHeight - (params.DifficultyAdjustmentInterval()-1);
+        assert(nHeightFirst >= 0);
+        const CBlockIndex* pindexFirst = pindexLast->GetAncestor(nHeightFirst);
+        assert(pindexFirst);
+
+        nBits = CalculateNextWorkRequired(pindexLast, pindexFirst->GetBlockTime(), params);
     }
 
-    // Go back by what we want to be 14 days worth of blocks
-    int nHeightFirst = pindexLast->nHeight - (params.DifficultyAdjustmentInterval()-1);
-    assert(nHeightFirst >= 0);
-    const CBlockIndex* pindexFirst = pindexLast->GetAncestor(nHeightFirst);
-    assert(pindexFirst);
-
-    return CalculateNextWorkRequired(pindexLast, pindexFirst->GetBlockTime(), params);
+    return nBits;
 }
 
 unsigned int CalculateNextWorkRequired(const CBlockIndex* pindexLast, int64_t nFirstBlockTime, const Consensus::Params& params)

--- a/src/primitives/block.cpp
+++ b/src/primitives/block.cpp
@@ -46,7 +46,7 @@ uint256 CBlockHeader::GetHash() const
     h1 << m_reserved;
     h1 << m_xor_key_mask_clear_bits;
     h1 << xor_key_hash.GetSHA256();
-    Assert(h1.BytesWritten() == 0x40 + 88);
+    Assert(h1.BytesWritten() == 0x40 + 90);
 
     auto h2 = TaggedHash("Merge-mining hook");
     h2 << h1.GetSHA256();

--- a/src/primitives/block.cpp
+++ b/src/primitives/block.cpp
@@ -48,15 +48,22 @@ uint256 CBlockHeader::GetHash() const
     h1 << xor_key_hash.GetSHA256();
     Assert(h1.BytesWritten() == 0x40 + 88);
 
+    auto h2 = TaggedHash("Merge-mining hook");
+    h2 << h1.GetSHA256();
+    h2 << m_mm_rhs;
+    Assert(h2.BytesWritten() == 0x40 + 0x40);
+
+    // These fields get sent to mining machines over Sv1
     DataStream ss;
     ss << (uint32_t)0;     // Final 3 bytes are part of Sv1 "coinb1" (first is implied by hasher)
-    ss << h1.GetSHA256();  // Remainder of Sv1 "coinb1"
+    ss << h2.GetSHA256();  // Remainder of Sv1 "coinb1"
     ss << m_extranonce;    // Sv1 "extranonce"
     Assert(ss.size() == 52);
 
     uint256 hash;
     Assert(0 == blake2b((void*)hash.begin(), hash.size(), (void*)ss.data(), ss.size(), nullptr, 0));
 
+    // Presumably the actual mining ASIC hardware sees these
     ss.clear();
     ss << hashPrevBlock;
     ss << nNonce;

--- a/src/primitives/block.cpp
+++ b/src/primitives/block.cpp
@@ -5,12 +5,73 @@
 
 #include <primitives/block.h>
 
+#include <crypto/blake2.h>
 #include <hash.h>
+#include <streams.h>
 #include <tinyformat.h>
 
 uint256 CBlockHeader::GetHash() const
 {
-    return (HashWriter{} << *this).GetHash();
+    if (!m_header_v2) {  // SHA256d
+        // Historical algorithm and common case.
+        Assume(HeaderV2FieldsNull());
+        return (HashWriter{} << *this).GetHash();
+    }
+
+    // BLAKE2b
+
+    // The pooling miner doesn't know m_xor_key (only the hash of it) until it finds a block
+    auto xor_key_hash = TaggedHash("Bitcoin block hash PoW XOR key");
+    xor_key_hash << m_xor_key;
+    Assert(xor_key_hash.BytesWritten() == 0x40 + 0x10);  // TaggedHash adds 0x40 bytes extra
+
+    uint256 xor_key_mask;
+    if (!m_xor_key.IsNull()) {
+        xor_key_mask = (TaggedHash("Bitcoin block hash PoW XOR mask") << m_xor_key).GetSHA256();
+        const unsigned int xor_key_mask_clear_bytes = m_xor_key_mask_clear_bits / 8;
+        std::fill_n(xor_key_mask.begin(), xor_key_mask_clear_bytes, uint8_t{0});
+        xor_key_mask.begin()[xor_key_mask_clear_bytes] &= 0xffU >> (m_xor_key_mask_clear_bits % 8);
+    }
+
+    // These fields are invisible to the mining machine
+    // This means the hasher cannot brick itself at some future block version, time, or difficulty
+    auto h1 = TaggedHash("Bitcoin block header 1");
+    h1 << nVersion;
+    h1 << hashMerkleRoot;
+    h1 << nTime;
+    h1 << (uint32_t)0;  // Reserved for extended 64-bit time
+    h1 << nBits;
+    h1 << m_reserved1;
+    h1 << m_reserved;
+    h1 << m_xor_key_mask_clear_bits;
+    h1 << xor_key_hash.GetSHA256();
+    Assert(h1.BytesWritten() == 0x40 + 84);
+
+    DataStream ss;
+    ss << (uint32_t)0;     // Final 3 bytes are part of Sv1 "coinb1" (first is implied by hasher)
+    ss << h1.GetSHA256();  // Remainder of Sv1 "coinb1"
+    ss << m_extranonce;    // Sv1 "extranonce"
+    Assert(ss.size() == 52);
+
+    uint256 hash;
+    Assert(0 == blake2b((void*)hash.begin(), hash.size(), (void*)ss.data(), ss.size(), nullptr, 0));
+
+    ss.clear();
+    ss << hashPrevBlock;
+    ss << nNonce;
+    ss << m_nonce2;
+    ss << m_nonce3;
+    ss << hash;
+    Assert(ss.size() == 80);
+
+    Assert(0 == blake2b((void*)hash.begin(), hash.size(), (void*)ss.data(), ss.size(), nullptr, 0));
+
+    uint256 final_hash;
+    for (size_t i = 0; i < hash.size(); ++i) {
+        final_hash.end()[-1-i] = hash.begin()[i] ^ xor_key_mask.begin()[i];
+    }
+
+    return final_hash;
 }
 
 std::string CBlock::ToString() const

--- a/src/primitives/block.cpp
+++ b/src/primitives/block.cpp
@@ -38,6 +38,7 @@ uint256 CBlockHeader::GetHash() const
     auto h1 = TaggedHash("Bitcoin block header 1");
     h1 << nVersion;
     h1 << hashMerkleRoot;
+    h1 << m_height;
     h1 << nTime;
     h1 << (uint32_t)0;  // Reserved for extended 64-bit time
     h1 << nBits;
@@ -45,7 +46,7 @@ uint256 CBlockHeader::GetHash() const
     h1 << m_reserved;
     h1 << m_xor_key_mask_clear_bits;
     h1 << xor_key_hash.GetSHA256();
-    Assert(h1.BytesWritten() == 0x40 + 84);
+    Assert(h1.BytesWritten() == 0x40 + 88);
 
     DataStream ss;
     ss << (uint32_t)0;     // Final 3 bytes are part of Sv1 "coinb1" (first is implied by hasher)

--- a/src/primitives/block.cpp
+++ b/src/primitives/block.cpp
@@ -14,7 +14,7 @@ uint256 CBlockHeader::GetHash() const
 {
     if (!m_header_v2) {  // SHA256d
         // Historical algorithm and common case.
-        Assume(HeaderV2FieldsNull());
+        Assume(AreHeaderV2FieldsNull());
         return (HashWriter{} << *this).GetHash();
     }
 

--- a/src/primitives/block.cpp
+++ b/src/primitives/block.cpp
@@ -42,7 +42,7 @@ uint256 CBlockHeader::GetHash() const
     h1 << nTime;
     h1 << (uint32_t)0;  // Reserved for extended 64-bit time
     h1 << nBits;
-    h1 << m_reserved1;
+    h1 << (uint32_t)m_txcount;
     h1 << m_reserved;
     h1 << m_xor_key_mask_clear_bits;
     h1 << xor_key_hash.GetSHA256();

--- a/src/primitives/block.h
+++ b/src/primitives/block.h
@@ -41,17 +41,6 @@ struct CompressedHeader {
         hashMerkleRoot.SetNull();
     }
 
-    bool HeaderV2FieldsNull() const {
-        if (m_nonce2) return false;
-        if (m_nonce3) return false;
-        if (!m_extranonce.IsNull()) return false;
-        if (m_reserved1) return false;
-        if (m_reserved) return false;
-        if (m_xor_key_mask_clear_bits) return false;
-        if (!m_xor_key.IsNull()) return false;
-        return true;
-    }
-
     NodeSeconds Time() const
     {
         return NodeSeconds{std::chrono::seconds{nTime}};
@@ -129,6 +118,17 @@ public:
     bool IsNull() const
     {
         return (nBits == 0);
+    }
+
+    bool AreHeaderV2FieldsNull() const {
+        if (m_nonce2) return false;
+        if (m_nonce3) return false;
+        if (!m_extranonce.IsNull()) return false;
+        if (m_reserved1) return false;
+        if (m_reserved) return false;
+        if (m_xor_key_mask_clear_bits) return false;
+        if (!m_xor_key.IsNull()) return false;
+        return true;
     }
 
     uint256 GetHash() const;

--- a/src/primitives/block.h
+++ b/src/primitives/block.h
@@ -64,6 +64,7 @@ class CBlockHeader : public CompressedHeader
 public:
     // header
     uint256 hashPrevBlock;
+    int32_t m_height;
 
     CBlockHeader()
     {
@@ -71,9 +72,10 @@ public:
     }
 
     template <typename T> requires std::same_as<std::remove_cvref_t<T>, CompressedHeader>
-    CBlockHeader(T&& compressed_header, const uint256& hash_prev_block)
+    CBlockHeader(T&& compressed_header, const uint256& hash_prev_block, const int32_t height)
     : CompressedHeader(std::forward<T>(compressed_header)),
-      hashPrevBlock(hash_prev_block)
+      hashPrevBlock(hash_prev_block),
+      m_height(m_header_v2 ? height : 0)
     {
     }
 
@@ -85,7 +87,7 @@ public:
         SER_READ(obj, obj.m_header_v2 = v & v2_flag);
         SER_READ(obj, obj.nVersion = v & ~v2_flag);
         if (obj.m_header_v2) {
-            READWRITE(obj.m_nonce2, obj.m_nonce3, obj.m_extranonce, obj.m_reserved1, obj.m_reserved, obj.m_xor_key_mask_clear_bits, obj.m_xor_key);
+            READWRITE(obj.m_nonce2, obj.m_nonce3, obj.m_extranonce, obj.m_reserved1, obj.m_reserved, obj.m_xor_key_mask_clear_bits, obj.m_xor_key, obj.m_height);
         } else {
             SER_READ(obj, obj.m_nonce2 = 0);
             SER_READ(obj, obj.m_nonce3 = 0);
@@ -94,6 +96,7 @@ public:
             SER_READ(obj, obj.m_reserved = 0);
             SER_READ(obj, obj.m_xor_key_mask_clear_bits = 0);
             SER_READ(obj, obj.m_xor_key.SetNull());
+            SER_READ(obj, obj.m_height = 0);
         }
     }
 
@@ -113,6 +116,7 @@ public:
         m_reserved = 0;
         m_xor_key_mask_clear_bits = 0;
         m_xor_key.SetNull();
+        m_height = 0;
     }
 
     bool IsNull() const
@@ -128,6 +132,7 @@ public:
         if (m_reserved) return false;
         if (m_xor_key_mask_clear_bits) return false;
         if (!m_xor_key.IsNull()) return false;
+        if (m_height) return false;
         return true;
     }
 

--- a/src/primitives/block.h
+++ b/src/primitives/block.h
@@ -18,15 +18,38 @@
 // A compressed CBlockHeader, which leaves out the prevhash
 struct CompressedHeader {
     // header
+    bool m_header_v2{false};
     int32_t nVersion{0};
     uint256 hashMerkleRoot;
     uint32_t nTime{0};
     uint32_t nBits{0};
+    // Direct PoW/ASIC grinding:
     uint32_t nNonce{0};
+    uint32_t m_nonce2{0};
+    uint64_t m_nonce3{0};
+    // Sv1 extranonce:
+    uint128 m_extranonce{};
+    // Header 1 effectively-nonce, reserved:
+    uint16_t m_reserved1{0};
+    uint8_t m_reserved{0};
+
+    uint8_t m_xor_key_mask_clear_bits{0};
+    uint128 m_xor_key{};
 
     CompressedHeader()
     {
         hashMerkleRoot.SetNull();
+    }
+
+    bool HeaderV2FieldsNull() const {
+        if (m_nonce2) return false;
+        if (m_nonce3) return false;
+        if (!m_extranonce.IsNull()) return false;
+        if (m_reserved1) return false;
+        if (m_reserved) return false;
+        if (m_xor_key_mask_clear_bits) return false;
+        if (!m_xor_key.IsNull()) return false;
+        return true;
     }
 
     NodeSeconds Time() const
@@ -65,16 +88,42 @@ public:
     {
     }
 
-    SERIALIZE_METHODS(CBlockHeader, obj) { READWRITE(obj.nVersion, obj.hashPrevBlock, obj.hashMerkleRoot, obj.nTime, obj.nBits, obj.nNonce); }
+    SERIALIZE_METHODS(CBlockHeader, obj) {
+        constexpr uint32_t v2_flag{0x80000000UL};
+        uint32_t v;
+        SER_WRITE(obj, v = (obj.m_header_v2 ? v2_flag : (uint32_t)0) | (uint32_t)obj.nVersion);
+        READWRITE(v, obj.hashPrevBlock, obj.hashMerkleRoot, obj.nTime, obj.nBits, obj.nNonce);
+        SER_READ(obj, obj.m_header_v2 = v & v2_flag);
+        SER_READ(obj, obj.nVersion = v & ~v2_flag);
+        if (obj.m_header_v2) {
+            READWRITE(obj.m_nonce2, obj.m_nonce3, obj.m_extranonce, obj.m_reserved1, obj.m_reserved, obj.m_xor_key_mask_clear_bits, obj.m_xor_key);
+        } else {
+            SER_READ(obj, obj.m_nonce2 = 0);
+            SER_READ(obj, obj.m_nonce3 = 0);
+            SER_READ(obj, obj.m_extranonce.SetNull());
+            SER_READ(obj, obj.m_reserved1 = 0);
+            SER_READ(obj, obj.m_reserved = 0);
+            SER_READ(obj, obj.m_xor_key_mask_clear_bits = 0);
+            SER_READ(obj, obj.m_xor_key.SetNull());
+        }
+    }
 
     void SetNull()
     {
+        m_header_v2 = false;
         nVersion = 0;
         hashPrevBlock.SetNull();
         hashMerkleRoot.SetNull();
         nTime = 0;
         nBits = 0;
         nNonce = 0;
+        m_nonce2 = 0;
+        m_nonce3 = 0;
+        m_extranonce.SetNull();
+        m_reserved1 = 0;
+        m_reserved = 0;
+        m_xor_key_mask_clear_bits = 0;
+        m_xor_key.SetNull();
     }
 
     bool IsNull() const

--- a/src/primitives/block.h
+++ b/src/primitives/block.h
@@ -35,6 +35,7 @@ struct CompressedHeader {
 
     uint8_t m_xor_key_mask_clear_bits{0};
     uint128 m_xor_key{};
+    uint256 m_mm_rhs;
 
     CompressedHeader()
     {
@@ -87,7 +88,7 @@ public:
         SER_READ(obj, obj.m_header_v2 = v & v2_flag);
         SER_READ(obj, obj.nVersion = v & ~v2_flag);
         if (obj.m_header_v2) {
-            READWRITE(obj.m_nonce2, obj.m_nonce3, obj.m_extranonce, obj.m_reserved1, obj.m_reserved, obj.m_xor_key_mask_clear_bits, obj.m_xor_key, obj.m_height);
+            READWRITE(obj.m_nonce2, obj.m_nonce3, obj.m_extranonce, obj.m_reserved1, obj.m_reserved, obj.m_xor_key_mask_clear_bits, obj.m_xor_key, obj.m_height, obj.m_mm_rhs);
         } else {
             SER_READ(obj, obj.m_nonce2 = 0);
             SER_READ(obj, obj.m_nonce3 = 0);
@@ -97,6 +98,7 @@ public:
             SER_READ(obj, obj.m_xor_key_mask_clear_bits = 0);
             SER_READ(obj, obj.m_xor_key.SetNull());
             SER_READ(obj, obj.m_height = 0);
+            SER_READ(obj, obj.m_mm_rhs.SetNull());
         }
     }
 
@@ -117,6 +119,7 @@ public:
         m_xor_key_mask_clear_bits = 0;
         m_xor_key.SetNull();
         m_height = 0;
+        m_mm_rhs.SetNull();
     }
 
     bool IsNull() const

--- a/src/primitives/block.h
+++ b/src/primitives/block.h
@@ -30,12 +30,12 @@ struct CompressedHeader {
     // Sv1 extranonce:
     uint128 m_extranonce{};
     // Header 1 effectively-nonce, reserved:
-    uint16_t m_reserved1{0};
     uint8_t m_reserved{0};
 
     uint8_t m_xor_key_mask_clear_bits{0};
     uint128 m_xor_key{};
     uint256 m_mm_rhs;
+    uint16_t m_txcount{0};
 
     CompressedHeader()
     {
@@ -88,12 +88,12 @@ public:
         SER_READ(obj, obj.m_header_v2 = v & v2_flag);
         SER_READ(obj, obj.nVersion = v & ~v2_flag);
         if (obj.m_header_v2) {
-            READWRITE(obj.m_nonce2, obj.m_nonce3, obj.m_extranonce, obj.m_reserved1, obj.m_reserved, obj.m_xor_key_mask_clear_bits, obj.m_xor_key, obj.m_height, obj.m_mm_rhs);
+            READWRITE(obj.m_nonce2, obj.m_nonce3, obj.m_extranonce, obj.m_txcount, obj.m_reserved, obj.m_xor_key_mask_clear_bits, obj.m_xor_key, obj.m_height, obj.m_mm_rhs);
         } else {
             SER_READ(obj, obj.m_nonce2 = 0);
             SER_READ(obj, obj.m_nonce3 = 0);
             SER_READ(obj, obj.m_extranonce.SetNull());
-            SER_READ(obj, obj.m_reserved1 = 0);
+            SER_READ(obj, obj.m_txcount = 0);
             SER_READ(obj, obj.m_reserved = 0);
             SER_READ(obj, obj.m_xor_key_mask_clear_bits = 0);
             SER_READ(obj, obj.m_xor_key.SetNull());
@@ -114,7 +114,7 @@ public:
         m_nonce2 = 0;
         m_nonce3 = 0;
         m_extranonce.SetNull();
-        m_reserved1 = 0;
+        m_txcount = 0;
         m_reserved = 0;
         m_xor_key_mask_clear_bits = 0;
         m_xor_key.SetNull();
@@ -131,7 +131,7 @@ public:
         if (m_nonce2) return false;
         if (m_nonce3) return false;
         if (!m_extranonce.IsNull()) return false;
-        if (m_reserved1) return false;
+        if (m_height) return false;
         if (m_reserved) return false;
         if (m_xor_key_mask_clear_bits) return false;
         if (!m_xor_key.IsNull()) return false;

--- a/src/test/headers_sync_chainwork_tests.cpp
+++ b/src/test/headers_sync_chainwork_tests.cpp
@@ -143,4 +143,131 @@ BOOST_AUTO_TEST_CASE(headers_sync_state)
     BOOST_CHECK(result.success);
 }
 
+// End-to-end: a peer serving the PoW-change fork block presyncs successfully,
+// while a peer claiming the same target drop without an algorithm change is
+// still rejected. Mainnet consensus parameters, where the gate is live.
+// HeadersSyncState does not itself verify proof of work, so the headers here
+// are unmined; only nBits and connectivity matter to this path.
+BOOST_AUTO_TEST_CASE(headers_sync_powchange_fork)
+{
+    const auto mainnet = CreateChainParams(*m_node.args, ChainType::MAIN);
+    Consensus::Params params = mainnet->GetConsensus();
+    BOOST_CHECK(!params.fPowAllowMinDifficultyBlocks);
+
+    // Must be in the past: m_max_commitments is derived from wall clock minus
+    // the chain_start time, so a future fork time starves the commitment budget.
+    const int64_t hf_time = 1700000000;
+    const uint32_t tip_nbits = 0x1702905c;
+
+    // The fork point the peer's headers branch from: pre-fork, non-boundary.
+    uint256 start_hash{uint256::ONE};
+    CBlockIndex chain_start;
+    chain_start.nHeight = 800000;
+    chain_start.nBits = tip_nbits;
+    chain_start.nTime = hf_time - 6000;
+    chain_start.phashBlock = &start_hash;
+    BOOST_CHECK((chain_start.nHeight + 1) % params.DifficultyAdjustmentInterval() != 0);
+
+    arith_uint256 shifted;
+    shifted.SetCompact(tip_nbits);
+    shifted <<= params.Blake2bTargetShift;
+    const uint32_t fork_nbits = shifted.GetCompact();
+
+    // Schedule the PoW change. chain_start stays pre-fork.
+    // FIXME: params.HardforkTime = hf_time;
+
+    // Two headers building on chain_start. The second one is the variable:
+    // its timestamp decides whether it crosses the fork, and its nBits is what
+    // the difficulty gate judges.
+    // connect_hash must match m_last_header_received, which the sync seeds
+    // from chain_start->GetBlockHeader(), not from phashBlock.
+    const uint256 connect_hash{chain_start.GetBlockHeader().GetHash()};
+
+    auto build_chain = [&](uint32_t second_time, uint32_t second_nbits) {
+        std::vector<CBlockHeader> headers(2);
+        headers[0].nVersion = 4;
+        headers[0].hashPrevBlock = connect_hash;
+        headers[0].nTime = hf_time - 1200;
+        headers[0].nBits = tip_nbits;
+        headers[1].nVersion = 4;
+        headers[1].hashPrevBlock = headers[0].GetHash();
+        headers[1].nTime = second_time;
+        headers[1].nBits = second_nbits;
+        return headers;
+    };
+
+    // Keep the required work out of reach so the sync stays in PRESYNC.
+    const arith_uint256 minimum_required_work{UintToArith256(params.nMinimumChainWork)};
+
+    auto presyncs = [&](const std::vector<CBlockHeader>& headers) {
+        HeadersSyncState hss(/*id=*/0, params, &chain_start, minimum_required_work);
+        const auto result = hss.ProcessNextHeaders(headers, /*full_headers_message=*/true);
+        return result.success && hss.GetState() == HeadersSyncState::State::PRESYNC;
+    };
+
+    BOOST_CHECK_NE(fork_nbits, tip_nbits);
+
+    // Ordinary pre-fork chain, difficulty unchanged.
+    BOOST_CHECK(presyncs(build_chain(hf_time - 600, tip_nbits)));
+
+    // Crossing the fork with the shifted target: this is what used to abort.
+    BOOST_CHECK(presyncs(build_chain(hf_time, fork_nbits)));
+
+    // Claiming the shifted target without crossing the fork: still rejected.
+    BOOST_CHECK(!presyncs(build_chain(hf_time - 600, fork_nbits)));
+
+    // Crossing the fork but taking more slack than the shift grants: rejected.
+    arith_uint256 too_easy;
+    too_easy.SetCompact(fork_nbits);
+    too_easy <<= 4;
+    BOOST_CHECK(!presyncs(build_chain(hf_time, too_easy.GetCompact())));
+}
+
+// Adversarial: header timestamps are not monotonic in presync, so a peer can
+// alternate them across HardforkTime. If the shift is granted on every
+// algorithm difference rather than only on the forward crossing, each header
+// gets another 2^20 of slack and the chain collapses to powLimit for free.
+BOOST_AUTO_TEST_CASE(headers_sync_powchange_oscillation)
+{
+    const auto mainnet = CreateChainParams(*m_node.args, ChainType::MAIN);
+    Consensus::Params params = mainnet->GetConsensus();
+    const int64_t hf_time = 1700000000;
+    const uint32_t tip_nbits = 0x1702905c;
+
+    uint256 start_hash{uint256::ONE};
+    CBlockIndex chain_start;
+    chain_start.nHeight = 800000;
+    chain_start.nBits = tip_nbits;
+    chain_start.nTime = hf_time - 6000;
+    chain_start.phashBlock = &start_hash;
+
+    // FIXME: params.HardforkTime = hf_time;
+
+    std::vector<CBlockHeader> headers;
+    uint256 prev{chain_start.GetBlockHeader().GetHash()};
+    uint32_t nbits = tip_nbits;
+    for (int i = 0; i < 8; ++i) {
+        arith_uint256 t;
+        t.SetCompact(nbits);
+        t <<= params.Blake2bTargetShift;
+        const arith_uint256 lim = UintToArith256(params.powLimit);
+        if (t > lim) t = lim;
+        nbits = t.GetCompact();
+
+        CBlockHeader h;
+        h.nVersion = 4;
+        h.hashPrevBlock = prev;
+        // Alternate across the fork time on every header.
+        h.nTime = (i % 2 == 0) ? hf_time : hf_time - 600;
+        h.nBits = nbits;
+        headers.push_back(h);
+        prev = h.GetHash();
+    }
+
+    HeadersSyncState hss(0, params, &chain_start, UintToArith256(params.nMinimumChainWork));
+    const auto result = hss.ProcessNextHeaders(headers, true);
+    BOOST_TEST_MESSAGE("final nbits=" << std::hex << nbits << " accepted=" << result.success);
+    BOOST_CHECK(!result.success);
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/pow_tests.cpp
+++ b/src/test/pow_tests.cpp
@@ -208,4 +208,59 @@ BOOST_AUTO_TEST_CASE(ChainParams_SIGNET_sanity)
     sanity_check_chainparams(*m_node.args, ChainType::SIGNET);
 }
 
+/* The one-off PoW-change target shift must be accepted by the headers-sync
+ * anti-DoS gate, without loosening it in any other case. */
+BOOST_AUTO_TEST_CASE(powchange_permitted_difficulty_transition)
+{
+    const auto chainParams = CreateChainParams(*m_node.args, ChainType::MAIN);
+    Consensus::Params params = chainParams->GetConsensus();
+
+    // The gate is only live on networks without min-difficulty blocks.
+    BOOST_CHECK(!params.fPowAllowMinDifficultyBlocks);
+
+    const uint32_t tip_nbits = 0x1702905c;
+    CBlockIndex pindexLast;
+    pindexLast.nHeight = 800000;
+    pindexLast.nBits = tip_nbits;
+    // 800001 is not a retarget boundary.
+    BOOST_CHECK((pindexLast.nHeight + 1) % params.DifficultyAdjustmentInterval() != 0);
+
+    CBlockHeader block;
+
+    // With the fork unset, behaviour is unchanged in both directions.
+    const unsigned int inert_nbits = GetNextWorkRequired(&pindexLast, &block, params);
+    BOOST_CHECK_EQUAL(inert_nbits, tip_nbits);
+    BOOST_CHECK(PermittedDifficultyTransition(params, pindexLast.nHeight + 1, tip_nbits, inert_nbits));
+
+    // Schedule the fork; the next block is at the Blake2bHeight.
+    params.Blake2bHeight = pindexLast.nHeight + 1;
+
+    const unsigned int fork_nbits = GetNextWorkRequired(&pindexLast, &block, params);
+    BOOST_CHECK_NE(fork_nbits, tip_nbits);
+
+    // This is the call headerssync.cpp makes for every header in IBD. The
+    // shifted target is now accepted across the algorithm change.
+    BOOST_CHECK(PermittedDifficultyTransition(params, pindexLast.nHeight + 1, tip_nbits, fork_nbits));
+
+    // ...but only that exact value: an extra 2^4 of slack is still rejected.
+    arith_uint256 too_easy;
+    too_easy.SetCompact(fork_nbits);
+    too_easy <<= 4;
+    BOOST_CHECK(!PermittedDifficultyTransition(params, pindexLast.nHeight + 1, tip_nbits, too_easy.GetCompact()));
+
+    // ...and only when the algorithm actually changes. Claiming the shift
+    // between two pre-fork blocks is still rejected.
+    BOOST_CHECK(!PermittedDifficultyTransition(params, pindexLast.nHeight + 1, tip_nbits, fork_nbits));
+
+    // At a retarget boundary the shift is permitted on top of the 4x window,
+    // and values beyond that window are still rejected.
+    const int64_t boundary_height = 798336;
+    BOOST_CHECK_EQUAL(boundary_height % params.DifficultyAdjustmentInterval(), 0);
+    BOOST_CHECK(PermittedDifficultyTransition(params, boundary_height, tip_nbits, fork_nbits));
+    arith_uint256 beyond_window;
+    beyond_window.SetCompact(fork_nbits);
+    beyond_window <<= 3;
+    BOOST_CHECK(!PermittedDifficultyTransition(params, boundary_height, tip_nbits, beyond_window.GetCompact()));
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/uint256.h
+++ b/src/uint256.h
@@ -182,6 +182,9 @@ std::optional<uintN_t> FromUserHex(std::string_view input)
 }
 } // namespace detail
 
+class uint128 : public base_blob<128> {
+};
+
 /** 160-bit opaque blob.
  * @note This type is called uint160 for historical reasons only. It is an opaque
  * blob of 160 bits and has no integer operations.

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4684,6 +4684,12 @@ static bool ContextualCheckBlockHeaderVolatile(const CBlockHeader& block, BlockV
 {
     const Consensus::Params& consensusParams = chainman.GetConsensus();
 
+    if (block.m_header_v2) {
+        if (block.m_height != pindexPrev->nHeight + 1) {
+            return state.Invalid(BlockValidationResult::BLOCK_CONSENSUS, "bad-header-height", "Height in block header does not match prevblock height+1");
+        }
+    }
+
     // Mandatory signaling for deployments approaching max_activation_height
     for (int i = 0; i < (int)Consensus::MAX_VERSION_BITS_DEPLOYMENTS; i++) {
         const Consensus::DeploymentPos pos = static_cast<Consensus::DeploymentPos>(i);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4348,8 +4348,8 @@ static bool CheckBlockHeader(const CBlockHeader& block, BlockValidationState& st
             /*debug_message=*/"THIS SHOULD BE IMPOSSIBLE, PLEASE REPORT IT");
     }
 
-    if (block.m_header_v2) {
-        return state.Invalid(BlockValidationResult::BLOCK_INVALID_HEADER, "high-hash", "Block header V2 not actually supported");
+    if (block.m_header_v2 && block.m_height < consensusParams.DeploymentHeight(Consensus::DEPLOYMENT_BLAKE2B)) {
+        return state.Invalid(BlockValidationResult::BLOCK_INVALID_HEADER, "bad-version-sha256d", strprintf("Blocks require SHA256d PoW until height %s", consensusParams.DeploymentHeight(Consensus::DEPLOYMENT_BLAKE2B)));
     }
 
     // Check proof of work matches claimed amount
@@ -4687,6 +4687,10 @@ static bool ContextualCheckBlockHeaderVolatile(const CBlockHeader& block, BlockV
     if (block.m_header_v2) {
         if (block.m_height != pindexPrev->nHeight + 1) {
             return state.Invalid(BlockValidationResult::BLOCK_CONSENSUS, "bad-header-height", "Height in block header does not match prevblock height+1");
+        }
+    } else {
+        if (pindexPrev->nHeight + 1 >= consensusParams.DeploymentHeight(Consensus::DEPLOYMENT_BLAKE2B)) {
+            return state.Invalid(BlockValidationResult::BLOCK_INVALID_HEADER, "bad-version-blake2b", "New blocks require BLAKE2b PoW");
         }
     }
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4363,6 +4363,13 @@ static bool CheckMerkleRoot(const CBlock& block, BlockValidationState& state)
 {
     if (block.m_checked_merkle_root) return true;
 
+    if (block.m_txcount != (block.m_header_v2 ? block.vtx.size() : 0)) {
+        return state.Invalid(
+            /*result=*/BlockValidationResult::BLOCK_MUTATED,
+            /*reject_reason=*/"bad-txnlist-size",
+            /*debug_message=*/"Transaction list size doesn't match header");
+    }
+
     bool mutated;
     uint256 merkle_root = BlockMerkleRoot(block, &mutated);
     if (block.hashMerkleRoot != merkle_root) {

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4341,6 +4341,17 @@ void ChainstateManager::ReceivedBlockTransactions(const CBlock& block, CBlockInd
 
 static bool CheckBlockHeader(const CBlockHeader& block, BlockValidationState& state, const Consensus::Params& consensusParams, bool fCheckPOW = true)
 {
+    if ((!block.m_header_v2) && !block.HeaderV2FieldsNull()) {
+        return state.Invalid(
+            /*result=*/BlockValidationResult::BLOCK_MUTATED,
+            /*reject_reason=*/"error-headerv1-with-v2-fields",
+            /*debug_message=*/"THIS SHOULD BE IMPOSSIBLE, PLEASE REPORT IT");
+    }
+
+    if (block.m_header_v2) {
+        return state.Invalid(BlockValidationResult::BLOCK_INVALID_HEADER, "high-hash", "Block header V2 not actually supported");
+    }
+
     // Check proof of work matches claimed amount
     if (fCheckPOW && !CheckProofOfWork(block.GetHash(), block.nBits, consensusParams))
         return state.Invalid(BlockValidationResult::BLOCK_INVALID_HEADER, "high-hash", "proof of work failed");

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4341,7 +4341,7 @@ void ChainstateManager::ReceivedBlockTransactions(const CBlock& block, CBlockInd
 
 static bool CheckBlockHeader(const CBlockHeader& block, BlockValidationState& state, const Consensus::Params& consensusParams, bool fCheckPOW = true)
 {
-    if ((!block.m_header_v2) && !block.HeaderV2FieldsNull()) {
+    if ((!block.m_header_v2) && !block.AreHeaderV2FieldsNull()) {
         return state.Invalid(
             /*result=*/BlockValidationResult::BLOCK_MUTATED,
             /*reject_reason=*/"error-headerv1-with-v2-fields",

--- a/test/functional/feature_powchange.py
+++ b/test/functional/feature_powchange.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Exercise the proof-of-work-change plumbing on regtest.
+
+Uses the regtest-only -powchangetime option to schedule a PoW-algorithm change
+and verifies that:
+  * blocks before the change time hash with SHA256d,
+  * blocks at/after the change time hash with BLAKE2b,
+  * a later block whose timestamp reaches back before the change (so it would be
+    hashed with the previous algorithm) is rejected as 'pow-reversed'.
+"""
+
+from test_framework.blocktools import create_block, create_coinbase
+from test_framework.messages import CBlockHeader, blake2b, hash256, powhash, set_pow_change
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import assert_equal, assert_raises_rpc_error
+
+CHANGE_TIME = 1_500_000_000  # PoW change activates at this block time
+CHANGE_ALGO = blake2b
+CHANGE_ALGO_STR = 'blake2b'
+STEP = 600                   # ten-minute spacing between mocked block times
+
+
+class PowChangeTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.setup_clean_chain = True
+        self.num_nodes = 1
+        self.extra_args = [[f"-powchangetime={CHANGE_TIME}:{CHANGE_ALGO_STR}"]]
+
+    def header_bytes(self, blockhash):
+        return bytes.fromhex(self.nodes[0].getblock(blockhash, 0)[:160])
+
+    def run_test(self):
+        node = self.nodes[0]
+        addr = node.get_deterministic_priv_key().address
+        # Mirror the node's schedule so framework-constructed blocks hash the same.
+        set_pow_change(CHANGE_TIME, CHANGE_ALGO)
+
+        self.log.info("Blocks before the change time use SHA256d")
+        t = CHANGE_TIME - 20 * STEP
+        pre_hash = None
+        for _ in range(20):
+            node.setmocktime(t)
+            pre_hash = self.generatetoaddress(node, 1, addr)[0]
+            t += STEP
+        pre_header = self.header_bytes(pre_hash)
+        pre_time = int.from_bytes(pre_header[68:72], "little")
+        assert pre_time < CHANGE_TIME
+        assert_equal(pre_hash, hash256(pre_header)[::-1].hex())
+        assert_equal(pre_hash, powhash(pre_header, pre_time)[::-1].hex())
+
+        self.log.info("Blocks at/after the change time use BLAKE2b")
+        node.setmocktime(CHANGE_TIME)
+        self.generatetoaddress(node, 1, addr)
+        node.setmocktime(CHANGE_TIME + STEP)
+        post_hash = self.generatetoaddress(node, 1, addr)[0]
+        post_header = self.header_bytes(post_hash)
+        post_time = int.from_bytes(post_header[68:72], "little")
+        assert post_time >= CHANGE_TIME
+        # The framework's algorithm-aware hash matches the node's block hash...
+        assert_equal(post_hash, powhash(post_header, post_time)[::-1].hex())
+
+        self.log.info("A block reaching back before the change is rejected (pow-reversed)")
+        tip = node.getbestblockhash()
+        reversed_block = create_block(int(tip, 16), create_coinbase(node.getblockcount() + 1), CHANGE_TIME - 1)
+        reversed_block.solve()
+        assert_raises_rpc_error(
+            -25, "pow-reversed",
+            lambda: node.submitheader(hexdata=CBlockHeader(reversed_block).serialize().hex()),
+        )
+
+
+if __name__ == "__main__":
+    PowChangeTest(__file__).main()

--- a/test/functional/interface_zmq.py
+++ b/test/functional/interface_zmq.py
@@ -258,7 +258,7 @@ class ZMQTest (BitcoinTestFramework):
             assert block.is_valid()
             assert_equal(block.vtx[0].hash, tx.hash)
             assert_equal(len(block.vtx), 1)
-            assert_equal(genhashes[x], hash256_reversed(hex[:80]).hex())
+            assert_equal(genhashes[x], block.hash)
 
             if self.is_wallet_compiled():
                 # Should receive wallet tx

--- a/test/functional/rpc_blockchain.py
+++ b/test/functional/rpc_blockchain.py
@@ -40,6 +40,7 @@ from test_framework.blocktools import (
     target_str,
 )
 from test_framework.messages import (
+    CBlock,
     CBlockHeader,
     COIN,
     from_hex,
@@ -632,8 +633,9 @@ class BlockchainTest(BitcoinTestFramework):
         blockhash = self.generate(node, 1)[0]
 
         def assert_hexblock_hashes(verbosity):
-            block = node.getblock(blockhash, verbosity)
-            assert_equal(blockhash, hash256(bytes.fromhex(block[:160]))[::-1].hex())
+            block = from_hex(CBlock(), node.getblock(blockhash, verbosity))
+            block.rehash()
+            assert_equal(blockhash, block.hash)
 
         def assert_fee_not_in_block(hash, verbosity):
             block = node.getblock(hash, verbosity)

--- a/test/functional/test_framework/messages.py
+++ b/test/functional/test_framework/messages.py
@@ -99,6 +99,33 @@ def hash256(s):
     return sha256(sha256(s))
 
 
+def blake2b(s):
+    return hashlib.blake2b(s, digest_size=32).digest()
+
+
+# PoW-change schedule mirrored from the node so block hashes match. Inert by
+# default (every block is SHA256d), matching a default regtest node. A test that
+# starts a node with -powchangetime must mirror it here via set_pow_change().
+_pow_change_time = None
+_pow_change_algo = blake2b
+
+
+def set_pow_change(change_time, algo=blake2b):
+    """Mirror a node's -powchangetime=time[:algo] configuration so that powhash()
+    selects the same algorithm the node's PowAlgorithmForTime() does."""
+    global _pow_change_time, _pow_change_algo
+    _pow_change_time = change_time
+    _pow_change_algo = algo
+
+
+def powhash(s, n_time):
+    """Proof-of-work hash of a serialized 80-byte header, selecting the algorithm
+    the way Consensus::Params::PowAlgorithmForTime() does."""
+    if _pow_change_time is None or n_time < _pow_change_time:
+        return hash256(s)
+    return _pow_change_algo(s)
+
+
 def ser_compact_size(l):
     r = b""
     if l < 253:
@@ -748,8 +775,9 @@ class CBlockHeader:
             r += self.nTime.to_bytes(4, "little")
             r += self.nBits.to_bytes(4, "little")
             r += self.nNonce.to_bytes(4, "little")
-            self.sha256 = uint256_from_str(hash256(r))
-            self.hash = hash256(r)[::-1].hex()
+            rawhash = powhash(r, self.nTime)
+            self.sha256 = uint256_from_str(rawhash)
+            self.hash = rawhash[::-1].hex()
 
     def rehash(self):
         self.sha256 = None

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -365,6 +365,7 @@ BASE_SCRIPTS = [
     'rpc_estimatefee.py',
     'rpc_getblockstats.py',
     'feature_port.py',
+    'feature_powchange.py',
     'feature_bind_port_externalip.py',
     'wallet_create_tx.py --legacy-wallet',
     'wallet_send.py --legacy-wallet',


### PR DESCRIPTION
The assertion closing the `h1` construction in `CBlockHeader::GetHash()` expects 88 bytes, but the fields written into it add up to 90:

| field | bytes |
| --- | --- |
| `nVersion` | 4 |
| `hashMerkleRoot` | 32 |
| `m_height` | 4 |
| `nTime` | 4 |
| reserved for extended 64-bit time | 4 |
| `nBits` | 4 |
| `m_txcount` | 4 |
| `m_reserved` | 1 |
| `m_xor_key_mask_clear_bits` | 1 |
| `xor_key_hash.GetSHA256()` | 32 |
| **total** | **90** |

`m_reserved` and `m_xor_key_mask_clear_bits` are the two that are unaccounted for.

Since `Assert()` aborts rather than warning, this is not cosmetic: the first block mined at or after the BLAKE2b activation height kills the node.

### Reproduction

Build with `-D RDTS_CONSENT=RUNTIME_CHECK`, then on a fresh regtest datadir with `consensusrules=rdts` set:

```
bitcoind -regtest -testactivationheight=blake2b@3
bitcoin-cli -regtest generatetoaddress 4 <addr>
```

The node aborts as soon as it mines the first block at the activation height:

```
./primitives/block.cpp:49 GetHash: Assertion `h1.BytesWritten() == 0x40 + 88' failed.
```

and the RPC client gets `Could not connect to the server ... EOF reached`, because the process is gone mid-request.

Note that reaching this point also needs #22, otherwise the node crashes on genesis before any block can be mined.

### After

With the count corrected, the same run mines across the switch and the node stays up:

```
176a53783b817de33ba73136e14e12b9694105e82bf6dec4b8d71a4ea657b965
32f612161e266dd48adcd0e3768039c31fadd4e17b095a031be1e3b22ca27105
721312aee68d6979d8fba06fb9c90e236c9ab50805b17850eae8cbe6817efc63
0235f148314c96c3bd92d0e68ac85c324210c9b24dd25d1eb28306da6d7ea4f2
```

Refs bitcoinknots/bitcoin#359.
