### PR TITLE
validation: Fix null pindexPrev deref on genesis

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2757,11 +2757,6 @@ bool Chainstate::ConnectBlock(const CBlock& block, BlockValidationState& state, 
     uint256 hashPrevBlock = pindex->pprev == nullptr ? uint256() : pindex->pprev->GetBlockHash();
     assert(hashPrevBlock == view.GetBestBlock());
 
-    if (!ContextualCheckBlockHeaderVolatile(block, state, m_chainman, pindex->pprev)) {
-        LogError("%s: Consensus::ContextualCheckBlockHeaderVolatile: %s\n", __func__, state.ToString());
-        return false;
-    }
-
     m_chainman.num_blocks_total++;
 
     // Special case for the genesis block, skipping connection of its transactions
@@ -2770,6 +2765,13 @@ bool Chainstate::ConnectBlock(const CBlock& block, BlockValidationState& state, 
         if (!fJustCheck)
             view.SetBestBlock(pindex->GetBlockHash());
         return true;
+    }
+
+    // Genesis has no previous block, so this must come after the special case
+    // above: ContextualCheckBlockHeaderVolatile dereferences pindexPrev.
+    if (!ContextualCheckBlockHeaderVolatile(block, state, m_chainman, pindex->pprev)) {
+        LogError("%s: Consensus::ContextualCheckBlockHeaderVolatile: %s\n", __func__, state.ToString());
+        return false;
     }
 
     bool fScriptChecks = true;


### PR DESCRIPTION
`ContextualCheckBlockHeaderVolatile()` dereferences `pindexPrev`, but `ConnectBlock()` calls it with `pindex->pprev` ahead of the genesis special case, so connecting the genesis block passes `nullptr`.

The line immediately above the call already accounts for `pprev` being null:

```cpp
uint256 hashPrevBlock = pindex->pprev == nullptr ? uint256() : pindex->pprev->GetBlockHash();
```

### Symptom

Any node started on a fresh datadir crashes while connecting genesis, on every network. Clean build of the branch tip, plain `-regtest`, no extra options:

```
Block index and chainstate loaded
Setting NODE_NETWORK in non-prune mode
initload thread start

Thread 27 "b-initload" received signal SIGSEGV, Segmentation fault.
ContextualCheckBlockHeaderVolatile (block=..., state=..., chainman=..., pindexPrev=0x0) at validation.cpp:4694
#1  Chainstate::ConnectBlock (...) at validation.cpp:2760
#2  Chainstate::ConnectTip (...) at validation.cpp:3576
#3  Chainstate::ActivateBestChainStep (...) at validation.cpp:3781
#4  Chainstate::ActivateBestChain (...) at validation.cpp:3922
#5  node::ImportBlocks (...) at node/blockstorage.cpp:1418
```

The genesis block is the one block with no parent, so `pindexPrev->nHeight` is a null dereference every time.

### Fix

Move the call below the genesis special case, which already returns early for that block. An alternative would be an early `pindexPrev == nullptr` return inside the function; this way keeps the function's existing precondition intact.

### After

Same clean build with the patch, fresh regtest datadir, `-testactivationheight=blake2b@3`, mining across the switch:

```
$ bitcoin-cli -regtest getblockcount
0
$ bitcoin-cli -regtest generatetoaddress 6 <addr>
176a53783b817de33ba73136e14e12b9694105e82bf6dec4b8d71a4ea657b965
32f612161e266dd48adcd0e3768039c31fadd4e17b095a031be1e3b22ca27105
721312aee68d6979d8fba06fb9c90e236c9ab50805b17850eae8cbe6817efc63
0235f148314c96c3bd92d0e68ac85c324210c9b24dd25d1eb28306da6d7ea4f2
1fb4d9f9473d8a94387246dceaa418ab8f35291adac176ef5956a201c58e2b22
4bcaa268e3eb630bc1d191a69e11c389279800e12fb10220babb603c005a9ced
```

Blocks 1 and 2 are SHA256d, activation lands at height 3, and blocks 3 to 6 are mined under BLAKE2b.

Introduced in 0855b1fd3a. Refs bitcoinknots/bitcoin#359.
